### PR TITLE
On first succesfull login against LDAP, user.id is not propagated to …

### DIFF
--- a/api/services/protocols/ldap.js
+++ b/api/services/protocols/ldap.js
@@ -38,7 +38,7 @@ var ldapToUser = function (ldapUser, user, next) {
                 console.error("Failed to create user from ldap", err);
                 next(err);
             } else {
-                next(null, data);
+                next(null, user);
             }
         });
     }


### PR DESCRIPTION
…next(), hence login fails